### PR TITLE
fix: exit with code 0 when successfull

### DIFF
--- a/inpainting/inpaint.py
+++ b/inpainting/inpaint.py
@@ -427,7 +427,9 @@ def main():
                 with open(f'{args.out}_{i_des}_translated_coords.json', "w") as outfile:
                     json.dump(translate_dict, outfile)
             '''
-    sys.exit('Successfully wrote output')
+
+    print('Successfully wrote output')
+    sys.exit(0)
         
 
     


### PR DESCRIPTION
Exiting with the string 'Successfully wrote output' makes is look like the program failed since the exit code is not 0.